### PR TITLE
Added support for passing additional startup options and start timeout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
@@ -179,13 +179,7 @@ public class MongoBuildWrapper extends BuildWrapper {
             dbpathFile = workspace.child("data").child("db");
         } else {
             dbpathFile = new FilePath(launcher.getChannel(),dbpath);
-            boolean isAbsolute = dbpathFile.act(new FileCallable<Boolean>() {
-
-				public Boolean invoke(File f, VirtualChannel channel){
-					return f.isAbsolute();
-				}
-			});
-            
+            boolean isAbsolute = dbpathFile.act(new IsAbsoluteCheck());
             if (!isAbsolute) {
                 dbpathFile = workspace.child(dbpath);
             }
@@ -371,4 +365,11 @@ public class MongoBuildWrapper extends BuildWrapper {
             return m;
         }
     }
+    
+    private static class IsAbsoluteCheck implements FileCallable<Boolean> {
+
+		public Boolean invoke(File f, VirtualChannel channel){
+			return f.isAbsolute();
+		}
+	}
 }

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
@@ -1,9 +1,11 @@
 package org.jenkinsci.plugins.mongodb;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_InvalidPortNumber;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_NotDirectory;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_NotEmptyDirectory;
+import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_InvalidStartTimeout;
 import hudson.CopyOnWrite;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -34,6 +36,7 @@ import java.net.URL;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -43,14 +46,18 @@ public class MongoBuildWrapper extends BuildWrapper {
     private String mongodbName;
     private String dbpath;
     private String port;
+	private String parameters;
+	private int startTimeout;
 
     public MongoBuildWrapper() {}
 
     @DataBoundConstructor
-    public MongoBuildWrapper(String mongodbName, String dbpath, String port) {
+    public MongoBuildWrapper(String mongodbName, String dbpath, String port, String parameters, int startTimeout) {
         this.mongodbName = mongodbName;
         this.dbpath = dbpath;
         this.port = port;
+		this.startTimeout = startTimeout;
+		this.parameters = parameters;
     }
 
     public MongoDBInstallation getMongoDB() {
@@ -86,7 +93,27 @@ public class MongoBuildWrapper extends BuildWrapper {
         this.port = port;
     }
 
-    @Override
+    public String getParameters() {
+		return parameters;
+	}
+
+	public void setParameters(String parameters) {
+		this.parameters = parameters;
+	}
+
+	/**
+	 * The time (in milliseconds) to wait for mongodb to start
+	 * @return time in milliseconds
+	 */
+	public int getStartTimeout() {
+		return startTimeout;
+	}
+
+	public void setStartTimeout(int startTimeout) {
+		this.startTimeout = startTimeout;
+	}
+
+	@Override
     public Environment setUp(AbstractBuild build, final Launcher launcher, final BuildListener listener) throws IOException, InterruptedException {
 
         EnvVars env = build.getEnvironment(listener);
@@ -95,20 +122,28 @@ public class MongoBuildWrapper extends BuildWrapper {
             .forNode(Computer.currentComputer().getNode(), listener)
             .forEnvironment(env);
         ArgumentListBuilder args = new ArgumentListBuilder().add(mongo.getExecutable(launcher));
-        final FilePath dbpathFile = setupCmd(launcher,args, build.getWorkspace(), false);
+        String globalParameters = mongo.getParameters();
+        int globalStartTimeout = mongo.getStartTimeout();
+        final FilePath dbpathFile = setupCmd(launcher,args, build.getWorkspace(), false, globalParameters);
 
     	dbpathFile.deleteRecursive();
     	dbpathFile.mkdirs();
-        return launch(launcher, args, listener);
+        return launch(launcher, args, listener, globalStartTimeout);
     }
 
-    protected Environment launch(final Launcher launcher, ArgumentListBuilder args, final BuildListener listener) throws IOException, InterruptedException {
+    protected Environment launch(final Launcher launcher, ArgumentListBuilder args, final BuildListener listener, int globalStartTimeout) throws IOException, InterruptedException {
         ProcStarter procStarter = launcher.launch().cmds(args);
         log(listener, "Executing mongodb start command: "+procStarter.cmds());
 		final Proc proc = procStarter.start();
 
         try {
-            Boolean startResult = launcher.getChannel().call(new WaitForStartCommand(listener, port));
+        	
+        	int effectiveTimeout = globalStartTimeout;
+        	if(startTimeout>0) {
+        		effectiveTimeout = startTimeout;
+        	}
+        	
+            Boolean startResult = launcher.getChannel().call(new WaitForStartCommand(listener, port, effectiveTimeout));
             if(!startResult) {
                 log(listener, "ERROR: Filed to start mongodb");
             }
@@ -132,7 +167,7 @@ public class MongoBuildWrapper extends BuildWrapper {
         };
     }
 
-    protected FilePath setupCmd(Launcher launcher, ArgumentListBuilder args, FilePath workspace, boolean fork) throws IOException, InterruptedException {
+    protected FilePath setupCmd(Launcher launcher, ArgumentListBuilder args, FilePath workspace, boolean fork, String globalParameters) throws IOException, InterruptedException {
 
         if (fork) {
         	args.add("--fork");
@@ -161,6 +196,30 @@ public class MongoBuildWrapper extends BuildWrapper {
         if (StringUtils.isNotEmpty(port)) {
             args.add("--port", port);
         }
+        String effectiveParameters = globalParameters;
+        if (StringUtils.isNotEmpty(parameters)) {
+        	effectiveParameters = parameters;
+        }
+        
+        if (StringUtils.isNotEmpty(effectiveParameters)) {
+        	for (String parameter : effectiveParameters.split("--")) {
+        		
+        		if(parameter.trim().indexOf(" ")!=-1) {
+        			//The parameter is a name value pair e.g. --syncdelay 0
+        			// The construction is done this way so the case where the value is in quotes and possibly contains space chars is properly handled 
+        			String parameterName = parameter.trim().substring(0, parameter.trim().indexOf(" ")).trim();
+        			String parameterValue = parameter.trim().substring(parameter.trim().indexOf(" ")).trim();
+        			if(StringUtils.isNotEmpty(parameterName)) {
+        				args.add("--"+parameterName, parameterValue);
+        			}
+        		} else {
+        			//No value parameter e.g. --noprealloc
+        			if(StringUtils.isNotEmpty(parameter.trim())) {
+        				args.add("--"+parameter.trim());
+        			}
+        		}
+			}
+        }
 
         return dbpathFile;
     }
@@ -171,20 +230,26 @@ public class MongoBuildWrapper extends BuildWrapper {
 
     private static class WaitForStartCommand implements Callable<Boolean, Exception> {
 
-        private static final int MAX_RETRY = 5;
-
-        private int retryCount;
-
         private BuildListener listener;
 
         private String port;
 
-        public WaitForStartCommand(BuildListener listener, String port) {
+		private int startTimeout;
+
+		private long waitStart;
+
+        public WaitForStartCommand(BuildListener listener, String port, int startTimeout) {
             this.listener = listener;
             this.port = StringUtils.defaultIfEmpty(port, "27017");
+            if(startTimeout == 0) {
+            	this.startTimeout = 15000;
+            } else {
+            	this.startTimeout = startTimeout;
+            }
         }
 
         public Boolean call() throws Exception {
+        	waitStart = System.currentTimeMillis();
             return waitForStart();
         }
 
@@ -203,8 +268,8 @@ public class MongoBuildWrapper extends BuildWrapper {
                 throw e;
             } catch (ConnectException e) {
                 try {
-                    if (++retryCount <= MAX_RETRY) {
-                        Thread.sleep(3000);
+                    if (startTimeout>=System.currentTimeMillis()-waitStart) {
+                        Thread.sleep(1000);
                         return waitForStart();
                     } else {
                         return false;
@@ -256,6 +321,19 @@ public class MongoBuildWrapper extends BuildWrapper {
             save();
         }
 
+        public static FormValidation doCheckStartTimeout(@QueryParameter String value) {
+        	if(isEmpty(value)) {
+        		return FormValidation.ok();
+        	}
+        	
+        	try {
+        		int timeout = Integer.parseInt(value);
+        		return timeout>0 ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidStartTimeout());
+        	} catch (NumberFormatException e) {
+        		return FormValidation.error(MongoDB_InvalidStartTimeout());
+        	}
+        }
+        
         public static FormValidation doCheckPort(@QueryParameter String value) {
             return isPortNumber(value) ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidPortNumber());
         }

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoDBInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoDBInstallation.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.mongodb;
 
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_InvalidStartTimeout;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_NotDirectory;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_NotMongoDBDirectory;
 import hudson.EnvVars;
@@ -15,7 +17,9 @@ import hudson.slaves.NodeSpecific;
 import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstaller;
 import hudson.tools.ToolProperty;
+import hudson.tools.ToolPropertyDescriptor;
 import hudson.tools.ToolInstallation;
+import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 
 import java.io.File;
@@ -25,23 +29,47 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 public class MongoDBInstallation extends ToolInstallation implements EnvironmentSpecific<MongoDBInstallation>, NodeSpecific<MongoDBInstallation> {
 
-    @DataBoundConstructor
-    public MongoDBInstallation(String name, String home, List<? extends ToolProperty<?>> properties) {
+    private String parameters;
+	
+	private int startTimeout;
+
+	@DataBoundConstructor
+    public MongoDBInstallation(String name, String home, List<? extends ToolProperty<?>> properties, String parameters, int startTimeout) {
         super(name, home, properties);
+		this.parameters = parameters;
+		this.startTimeout = startTimeout;
     }
 
     public MongoDBInstallation forNode(Node node, TaskListener log) throws IOException, InterruptedException {
-        return new MongoDBInstallation(getName(), translateFor(node, log), getProperties().toList());
+        return new MongoDBInstallation(getName(), translateFor(node, log), getProperties().toList(), parameters, startTimeout);
     }
 
     public MongoDBInstallation forEnvironment(EnvVars environment) {
-        return new MongoDBInstallation(getName(), environment.expand(getHome()), getProperties().toList());
+        return new MongoDBInstallation(getName(), environment.expand(getHome()), getProperties().toList(), parameters, startTimeout);
     }
+    
+    public String getParameters() {
+		return parameters;
+	}
+
+	public void setParameters(String parameters) {
+		this.parameters = parameters;
+	}
+
+	public int getStartTimeout() {
+		return startTimeout;
+	}
+
+	public void setStartTimeout(int startTimeout) {
+		this.startTimeout = startTimeout;
+	}
+
 
     public String getExecutable(final Launcher launcher) throws IOException, InterruptedException {
         return launcher.getChannel().call(new Callable<String, IOException>() {
@@ -101,9 +129,32 @@ public class MongoDBInstallation extends ToolInstallation implements Environment
             Hudson.getInstance().getDescriptorByType(MongoBuildWrapper.DescriptorImpl.class).setInstallations(installations);
         }
 
-        public static FormValidation doCheckName(@QueryParameter String value) {
-            return FormValidation.validateRequired(value);
+
+		public static FormValidation doCheckName(@QueryParameter String value) {
+			if(isEmpty(value)) {
+        		return FormValidation.ok();
+        	}
+        	
+        	try {
+        		int timeout = Integer.parseInt(value);
+        		return timeout>0 ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidStartTimeout());
+        	} catch (NumberFormatException e) {
+        		return FormValidation.error(MongoDB_InvalidStartTimeout());
+        	}
         }
+		
+		public static FormValidation doCheckStartTimeout(@QueryParameter String value) {
+			if(isEmpty(value)) {
+        		return FormValidation.ok();
+        	}
+        	
+        	try {
+        		int timeout = Integer.parseInt(value);
+        		return timeout>0 ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidStartTimeout());
+        	} catch (NumberFormatException e) {
+        		return FormValidation.error(MongoDB_InvalidStartTimeout());
+        	}
+	    }
 
         public static FormValidation doCheckHome(@QueryParameter File value) {
             if (StringUtils.isEmpty(value.getPath()))

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoDBInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoDBInstallation.java
@@ -130,17 +130,8 @@ public class MongoDBInstallation extends ToolInstallation implements Environment
         }
 
 
-		public static FormValidation doCheckName(@QueryParameter String value) {
-			if(isEmpty(value)) {
-        		return FormValidation.ok();
-        	}
-        	
-        	try {
-        		int timeout = Integer.parseInt(value);
-        		return timeout>0 ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidStartTimeout());
-        	} catch (NumberFormatException e) {
-        		return FormValidation.error(MongoDB_InvalidStartTimeout());
-        	}
+        public static FormValidation doCheckName(@QueryParameter String value) {
+            return FormValidation.validateRequired(value);
         }
 		
 		public static FormValidation doCheckStartTimeout(@QueryParameter String value) {

--- a/src/main/resources/org/jenkinsci/plugins/mongodb/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/mongodb/Messages.properties
@@ -1,4 +1,5 @@
 MongoDB.InvalidPortNumber=Invalid port number.
+MongoDB.InvalidStartTimeout=Invalid start timeout.
 MongoDB.NotDirectory=Not a directory.
 MongoDB.NotEmptyDirectory=Not a empty directory. Before running job, the data directory is cleaned.
 MongoDB.NotMongoDBDirectory={0} doesn't look like an MongoDB directory.

--- a/src/main/resources/org/jenkinsci/plugins/mongodb/MongoBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mongodb/MongoBuildWrapper/config.jelly
@@ -8,4 +8,10 @@
   <f:entry title="${%Port}" field="port">
     <f:textbox />
   </f:entry>
+  <f:entry title="Startup Parameters" field="parameters">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="Start timeout" field="startTimeout">
+    <f:textbox />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/mongodb/MongoBuildWrapper/help-parameters.html
+++ b/src/main/resources/org/jenkinsci/plugins/mongodb/MongoBuildWrapper/help-parameters.html
@@ -1,0 +1,10 @@
+<div>
+Here you can specify additional mongod options.
+<p>You can find more information about the available options at 
+	<a target="_blank" href="http://docs.mongodb.org/manual/reference/mongod/">mongodb.org documentation</a>
+</p>
+<p>
+<b>Example:</b><br/>
+--noprealloc --smallfiles --syncdelay 0
+</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/mongodb/MongoBuildWrapper/help-startTimeout.html
+++ b/src/main/resources/org/jenkinsci/plugins/mongodb/MongoBuildWrapper/help-startTimeout.html
@@ -1,0 +1,7 @@
+<div>
+Here you can specify the time to wait (<b>in milliseconds</b>) for mongod to start.
+<p>
+<b>Example - wait 20 seconds for mongod to start:</b><br/>
+20000
+</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/mongodb/MongoDBInstallation/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mongodb/MongoDBInstallation/config.jelly
@@ -5,4 +5,10 @@
   <f:entry title="${%Install directory}" field="home">
     <f:textbox />
   </f:entry>
+  <f:entry title="Startup Parameters" field="parameters">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="Start timeout" field="startTimeout">
+    <f:textbox />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/mongodb/MongoDBInstallation/help-parameters.html
+++ b/src/main/resources/org/jenkinsci/plugins/mongodb/MongoDBInstallation/help-parameters.html
@@ -1,0 +1,10 @@
+<div>
+Here you can specify additional mongod options.
+<p>You can find more information about the available options at 
+	<a target="_blank" href="http://docs.mongodb.org/manual/reference/mongod/">mongodb.org documentation</a>
+</p>
+<p>
+<b>Example:</b><br/>
+--noprealloc --smallfiles --syncdelay 0
+</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/mongodb/MongoDBInstallation/help-startTimeout.html
+++ b/src/main/resources/org/jenkinsci/plugins/mongodb/MongoDBInstallation/help-startTimeout.html
@@ -1,0 +1,7 @@
+<div>
+Here you can specify the time to wait (<b>in milliseconds</b>) for mongod to start.
+<p>
+<b>Example - wait 20 seconds for mongod to start:</b><br/>
+20000
+</p>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapperTest.java
@@ -43,8 +43,8 @@ public class MongoBuildWrapperTest {
 
         ArgumentListBuilder args = new ArgumentListBuilder();
 
-        FilePath actualDbpath = new MongoBuildWrapper("mongo", null, null)
-            .setupCmd(mockLauncher,args, workspace, true);
+        FilePath actualDbpath = new MongoBuildWrapper("mongo", null, null, null, 0)
+            .setupCmd(mockLauncher,args, workspace, true,null);
         
         FilePath expectedDbpath = workspace.child("data").child("db");
         
@@ -62,8 +62,8 @@ public class MongoBuildWrapperTest {
         ArgumentListBuilder args = new ArgumentListBuilder();
         when(mockChannel.call((Callable) Mockito.any())).thenReturn(Boolean.FALSE);
         
-        FilePath actualDbpath = new MongoBuildWrapper("mongo", "data_dir", null)
-            .setupCmd(mockLauncher,args, workspace, true);
+        FilePath actualDbpath = new MongoBuildWrapper("mongo", "data_dir", null,null,0)
+            .setupCmd(mockLauncher,args, workspace, true,null);
 
         FilePath expectedDbpath = workspace.child("data_dir");
         FilePath expectedLogpath = workspace.child("mongodb.log");
@@ -81,8 +81,8 @@ public class MongoBuildWrapperTest {
         when(mockChannel.call((Callable) Mockito.any())).thenReturn(Boolean.TRUE);
         
         FilePath absolutePath = new FilePath(tempFolder.getRoot()).child("foo").child("bar").child("data_dir");
-        FilePath actualDbpath = new MongoBuildWrapper("mongo", absolutePath.getRemote(), null)
-            .setupCmd(mockLauncher,args, workspace, true);
+        FilePath actualDbpath = new MongoBuildWrapper("mongo", absolutePath.getRemote(), null,null,0)
+            .setupCmd(mockLauncher,args, workspace, true,null);
 
         assertEquals(absolutePath.getRemote(), actualDbpath.getRemote());
         
@@ -96,7 +96,7 @@ public class MongoBuildWrapperTest {
     public void setupCmd_with_port() throws Exception {
 
         ArgumentListBuilder args = new ArgumentListBuilder();
-        FilePath actualDbpath = new MongoBuildWrapper("mongo", null, "1234").setupCmd(mockLauncher,args, workspace, true);
+        FilePath actualDbpath = new MongoBuildWrapper("mongo", null, "1234", null,0).setupCmd(mockLauncher,args, workspace, true,null);
 
         FilePath expectedDbpath = workspace.child("data").child("db");
         assertEquals(expectedDbpath.getRemote(), actualDbpath.getRemote());
@@ -111,7 +111,7 @@ public class MongoBuildWrapperTest {
     public void setupCmd_without_fork() throws Exception{
 
     	ArgumentListBuilder args = new ArgumentListBuilder();
-        FilePath actualDbpath = new MongoBuildWrapper("mongo", null, "1234").setupCmd(mockLauncher,args, workspace, false);
+        FilePath actualDbpath = new MongoBuildWrapper("mongo", null, "1234", null,0).setupCmd(mockLauncher,args, workspace, false,null);
 
         FilePath expectedDbpath = workspace.child("data").child("db");
         assertEquals(expectedDbpath.getRemote(), actualDbpath.getRemote());
@@ -120,6 +120,60 @@ public class MongoBuildWrapperTest {
         		workspace.child("mongodb.log").getRemote(),
                 expectedDbpath.getRemote()),
             args.toStringWithQuote());
+    }
+    
+    @Test
+    public void setupCmd_with_parameters() throws Throwable {
+
+        ArgumentListBuilder args = new ArgumentListBuilder();
+        when(mockChannel.call((Callable) Mockito.any())).thenReturn(Boolean.FALSE);
+        
+        FilePath actualDbpath = new MongoBuildWrapper("mongo", "data_dir", null,"--smallfiles --syncdelay 0",0)
+            .setupCmd(mockLauncher,args, workspace, true,null);
+
+        FilePath expectedDbpath = workspace.child("data_dir");
+        FilePath expectedLogpath = workspace.child("mongodb.log");
+        assertEquals(expectedDbpath, actualDbpath);
+        assertEquals(format("--fork --logpath %s --dbpath %s --smallfiles --syncdelay 0",
+        		expectedLogpath.getRemote(),
+                expectedDbpath.getRemote()),
+            args.toStringWithQuote());
+    }
+    
+    @Test
+    public void setupCmd_with_parametersAndWhitespaces() throws Throwable {
+
+        ArgumentListBuilder args = new ArgumentListBuilder();
+        when(mockChannel.call((Callable) Mockito.any())).thenReturn(Boolean.FALSE);
+        
+        FilePath actualDbpath = new MongoBuildWrapper("mongo", "data_dir", null,"    --smallfiles       --syncdelay       0      ",0)
+            .setupCmd(mockLauncher,args, workspace, true,null);
+
+        FilePath expectedDbpath = workspace.child("data_dir");
+        FilePath expectedLogpath = workspace.child("mongodb.log");
+        assertEquals(expectedDbpath, actualDbpath);
+        assertEquals(format("--fork --logpath %s --dbpath %s --smallfiles --syncdelay 0",
+        		expectedLogpath.getRemote(),
+                expectedDbpath.getRemote()),
+            args.toStringWithQuote());
+    }
+    
+    @Test
+    public void setupCmd_with_parametersAndQuotes() throws Throwable {
+    	
+    	ArgumentListBuilder args = new ArgumentListBuilder();
+    	when(mockChannel.call((Callable) Mockito.any())).thenReturn(Boolean.FALSE);
+    	
+    	FilePath actualDbpath = new MongoBuildWrapper("mongo", "data_dir", null,"--smallfiles  --keyFile c:\\Program Files\\Secure\\somekeyfile",0)
+    	.setupCmd(mockLauncher,args, workspace, true,null);
+    	
+    	FilePath expectedDbpath = workspace.child("data_dir");
+    	FilePath expectedLogpath = workspace.child("mongodb.log");
+    	assertEquals(expectedDbpath, actualDbpath);
+    	assertEquals(format("--fork --logpath %s --dbpath %s --smallfiles --keyFile \"c:\\Program Files\\Secure\\somekeyfile\"",
+    			expectedLogpath.getRemote(),
+    			expectedDbpath.getRemote()),
+    			args.toStringWithQuote());
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapperValidationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapperValidationTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.mongodb;
 
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_InvalidPortNumber;
+import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_InvalidStartTimeout;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_NotDirectory;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_NotEmptyDirectory;
 import static org.junit.Assert.assertEquals;
@@ -25,6 +26,41 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Enclosed.class)
 public class MongoBuildWrapperValidationTest {
 
+	@RunWith(Parameterized.class)
+	public static class CheckStartTimeout {
+		
+		private String inputValue;
+		private Kind expectedKind;
+		private String expectedMessage;
+		
+		public CheckStartTimeout(String inputValue, Kind expectedKind, String expectedMessage) {
+			this.inputValue = inputValue;
+			this.expectedKind = expectedKind;
+			this.expectedMessage = expectedMessage;
+		}
+		
+		@Test
+		public void test() {
+			FormValidation actual = MongoBuildWrapper.DescriptorImpl.doCheckStartTimeout(inputValue);
+			assertEquals(expectedKind, actual.kind);
+			assertEquals(expectedMessage, actual.getMessage());
+		}
+		
+		@Parameters
+		public static Collection<Object[]> data() {
+			return Arrays.asList(
+					ok(""),
+					ok("27017"),
+					ok("65535"),
+					error(MongoDB_InvalidStartTimeout(),"0"),
+					error(MongoDB_InvalidStartTimeout(), "a"),
+					error(MongoDB_InvalidStartTimeout(), "-1"),					
+					error(MongoDB_InvalidStartTimeout(), "100.0"),
+					error(MongoDB_InvalidStartTimeout(), "100,0")
+					);
+		}
+	}
+	
     @RunWith(Parameterized.class)
     public static class CheckPort {
 

--- a/src/test/java/org/jenkinsci/plugins/mongodb/MongoDBInstallationValidationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mongodb/MongoDBInstallationValidationTest.java
@@ -8,10 +8,17 @@ import hudson.util.FormValidation.Kind;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 public class MongoDBInstallationValidationTest {
 
@@ -46,5 +53,55 @@ public class MongoDBInstallationValidationTest {
 
         FormValidation actual = doCheckHome(value);
         assertEquals(Kind.OK, actual.kind);
+    }
+    
+    @RunWith(Parameterized.class)
+	public static class CheckStartTimeout {
+		
+		private String inputValue;
+		private Kind expectedKind;
+		private String expectedMessage;
+		
+		public CheckStartTimeout(String inputValue, Kind expectedKind, String expectedMessage) {
+			this.inputValue = inputValue;
+			this.expectedKind = expectedKind;
+			this.expectedMessage = expectedMessage;
+		}
+		
+		@Test
+		public void test() {
+			FormValidation actual = MongoDBInstallation.DescriptorImpl.doCheckStartTimeout(inputValue);
+			assertEquals(expectedKind, actual.kind);
+			assertEquals(expectedMessage, actual.getMessage());
+		}
+		
+		@Parameters
+		public static Collection<Object[]> data() {
+			return Arrays.asList(
+					ok(""),
+					ok("27017"),
+					ok("65535"),
+					error(MongoDB_InvalidStartTimeout(),"0"),
+					error(MongoDB_InvalidStartTimeout(), "a"),
+					error(MongoDB_InvalidStartTimeout(), "-1"),					
+					error(MongoDB_InvalidStartTimeout(), "100.0"),
+					error(MongoDB_InvalidStartTimeout(), "100,0")
+					);
+		}
+	}
+    
+    private static Object[] ok(Object... params) {
+        return toParams(Kind.OK, null, params);
+    }
+
+    private static Object[] error(String message, Object... params) {
+        return toParams(Kind.ERROR, message, params);
+    }
+
+    private static Object[] toParams(Kind kind, String message, Object... params) {
+        List<Object> list = new ArrayList<Object>(Arrays.asList(params));
+        list.add(kind);
+        list.add(message);
+        return list.toArray(new Object[params.length + 2]);
     }
 }


### PR DESCRIPTION
Extended plugin to support specifying additional mongodb startup options
on global and job level. 
Added a field for specifying custom start timeout on global and job
level.
