### PR TITLE
Add support for MongoDB versions 3.6+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.classpath
 /.project
 /.settings
+/release.properties
+/pom.xml.releaseBackup

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /work
+/.classpath
+/.project
+/.settings

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>mongodb</artifactId>
-  <version>1.4-SNAPSHOT</version>
+  <version>1.4</version>
   <packaging>hpi</packaging>
   <name>Jenkins MongoDB Plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/MongoDB+Plugin</url>
@@ -55,6 +55,7 @@
   <scm>
     <connection>scm:git:git@github.com:jenkinsci/mongodb-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/mongodb-plugin.git</developerConnection>
+    <tag>mongodb-1.4</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>mongodb</artifactId>
-  <version>1.4</version>
+  <version>1.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins MongoDB Plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/MongoDB+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,11 @@
       <version>1.9.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongo-java-driver</artifactId>
+      <version>3.6.3</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>mongodb</artifactId>
-  <version>1.4-SNAPSHOT</version>
+  <version>1.4</version>
   <packaging>hpi</packaging>
   <name>Jenkins MongoDB Plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/MongoDB+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>mongodb</artifactId>
-  <version>1.4</version>
+  <version>1.4-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins MongoDB Plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/MongoDB+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.425</version>
+    <version>2.37</version>
   </parent>
 
   <artifactId>mongodb</artifactId>
@@ -23,7 +23,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.2</version>
       <scope>test</scope>
     </dependency>
      <dependency>

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
@@ -39,327 +39,328 @@ import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 
 public class MongoBuildWrapper extends BuildWrapper {
-	
-	private String mongodbName;
-	private String dbpath;
-	private String port;
-	private String parameters;
-	private int startTimeout;
-	
-	public MongoBuildWrapper() {
-	}
-	
-	@DataBoundConstructor
-	public MongoBuildWrapper(String mongodbName, String dbpath, String port, String parameters, int startTimeout) {
-		this.mongodbName = mongodbName;
-		this.dbpath = dbpath;
-		this.port = port;
-		this.startTimeout = startTimeout;
-		this.parameters = parameters;
-	}
-	
-	public MongoDBInstallation getMongoDB() {
-		for (MongoDBInstallation i : ((DescriptorImpl) getDescriptor()).getInstallations()) {
-			if (mongodbName != null && i.getName().equals(mongodbName)) {
-				return i;
-			}
-		}
-		return null;
-	}
-	
-	public String getMongodbName() {
-		return mongodbName;
-	}
-	
-	public String getDbpath() {
-		return dbpath;
-	}
-	
-	public String getPort() {
-		return port;
-	}
-	
-	public void setMongodbName(String mongodbName) {
-		this.mongodbName = mongodbName;
-	}
-	
-	public void setDbpath(String dbpath) {
-		this.dbpath = dbpath;
-	}
-	
-	public void setPort(String port) {
-		this.port = port;
-	}
-	
-	public String getParameters() {
-		return parameters;
-	}
-	
-	public void setParameters(String parameters) {
-		this.parameters = parameters;
-	}
-	
-	/**
-	 * The time (in milliseconds) to wait for mongodb to start
-	 * 
-	 * @return time in milliseconds
-	 */
-	public int getStartTimeout() {
-		return startTimeout;
-	}
-	
-	public void setStartTimeout(int startTimeout) {
-		this.startTimeout = startTimeout;
-	}
-	
-	@Override
-	public Environment setUp(AbstractBuild build, final Launcher launcher, final BuildListener listener)
-			throws IOException, InterruptedException {
-		
-		EnvVars env = build.getEnvironment(listener);
-		
-		MongoDBInstallation mongo = getMongoDB().forNode(Computer.currentComputer().getNode(), listener).forEnvironment(
-				env);
-		ArgumentListBuilder args = new ArgumentListBuilder().add(mongo.getExecutable(launcher));
-		String globalParameters = mongo.getParameters();
-		int globalStartTimeout = mongo.getStartTimeout();
-		final FilePath dbpathFile = setupCmd(launcher, args, build.getWorkspace(), false, globalParameters);
-		
-		dbpathFile.deleteRecursive();
-		dbpathFile.mkdirs();
-		return launch(launcher, args, listener, globalStartTimeout);
-	}
-	
-	protected Environment launch(final Launcher launcher, ArgumentListBuilder args, final BuildListener listener,
-			int globalStartTimeout) throws IOException, InterruptedException {
-		ProcStarter procStarter = launcher.launch().cmds(args);
-		log(listener, "Executing mongodb start command: " + procStarter.cmds());
-		final Proc proc = procStarter.start();
-		
-		try {
-			
-			int effectiveTimeout = globalStartTimeout;
-			if (startTimeout > 0) {
-				effectiveTimeout = startTimeout;
-			}
-			
-			Boolean startResult = launcher.getChannel().call(new WaitForStartCommand(listener, port, effectiveTimeout));
-			if (!startResult) {
-				log(listener, "ERROR: Failed to start mongodb");
-			}
-		} catch (Exception e) {
-			e.printStackTrace(listener.getLogger());
-			return null;
-		}
-		
-		return new BuildWrapper.Environment() {
-			@Override
-			public boolean tearDown(AbstractBuild build, BuildListener listener)
-					throws IOException, InterruptedException {
-				if (proc.isAlive()) {
-					log(listener, "Killing mongodb process...");
-					proc.kill();
-				} else {
-					log(listener, "Will not kill mongodb process as it is already dead.");
-				}
-				return super.tearDown(build, listener);
-			}
-		};
-	}
-	
-	protected FilePath setupCmd(Launcher launcher, ArgumentListBuilder args, FilePath workspace, boolean fork,
-			String globalParameters) throws IOException, InterruptedException {
-		
-		if (fork) {
-			args.add("--fork");
-		}
-		args.add("--logpath").add(workspace.child("mongodb.log").getRemote());
-		
-		FilePath dbpathFile;
-		if (isEmpty(dbpath)) {
-			dbpathFile = workspace.child("data").child("db");
-		} else {
-			dbpathFile = new FilePath(launcher.getChannel(), dbpath);
-			boolean isAbsolute = dbpathFile.act(new IsAbsoluteCheck());
-			if (!isAbsolute) {
-				dbpathFile = workspace.child(dbpath);
-			}
-		}
-		
-		args.add("--dbpath").add(dbpathFile.getRemote());
-		
-		if (StringUtils.isNotEmpty(port)) {
-			args.add("--port", port);
-		}
-		String effectiveParameters = globalParameters;
-		if (StringUtils.isNotEmpty(parameters)) {
-			effectiveParameters = parameters;
-		}
-		
-		if (StringUtils.isNotEmpty(effectiveParameters)) {
-			for (String parameter : effectiveParameters.split("--")) {
-				
-				if (parameter.trim().indexOf(" ") != -1) {
-					// The parameter is a name value pair e.g. --syncdelay 0
-					// The construction is done this way so the case where the value is in quotes and possibly contains
-					// space chars is properly handled
-					String parameterName = parameter.trim().substring(0, parameter.trim().indexOf(" ")).trim();
-					String parameterValue = parameter.trim().substring(parameter.trim().indexOf(" ")).trim();
-					if (StringUtils.isNotEmpty(parameterName)) {
-						args.add("--" + parameterName, parameterValue);
-					}
-				} else {
-					// No value parameter e.g. --noprealloc
-					if (StringUtils.isNotEmpty(parameter.trim())) {
-						args.add("--" + parameter.trim());
-					}
-				}
-			}
-		}
-		
-		return dbpathFile;
-	}
-	
-	private static void log(BuildListener listener, String log) {
-		listener.getLogger().println(String.format("[MongoDB] %s", log));
-	}
-	
-	private static class WaitForStartCommand implements Callable<Boolean, Exception> {
-		
-		private final BuildListener listener;
-		
-		private final String port;
-		
-		private int startTimeout;
-		
-		public WaitForStartCommand(BuildListener listener, String port, int startTimeout) {
-			this.listener = listener;
-			this.port = StringUtils.defaultIfEmpty(port, "27017");
-			if (startTimeout == 0) {
-				this.startTimeout = 15000;
-			} else {
-				this.startTimeout = startTimeout;
-			}
-		}
-		
-		public Boolean call() throws Exception {
-			return waitForStart();
-		}
-		
-		protected boolean waitForStart() throws Exception {
-			log(listener, "Starting...");
-			MongoClient mongo = null;
-			String address = "localhost:" + port;
-			try {
-				MongoClientOptions options = MongoClientOptions.builder().serverSelectionTimeout(startTimeout).build();
-				mongo = new MongoClient(address, options);
-				mongo.listDatabaseNames().first();
-				log(listener, "Server ready at " + address);
-				return true;
-			} catch (Exception e) {
-				throw e;
-			} finally {
-				if (mongo != null) {
-					mongo.close();
-				}
-			}
-		}
-	}
-	
-	@Extension
-	public static final class DescriptorImpl extends BuildWrapperDescriptor {
-		
-		@CopyOnWrite
-		private volatile MongoDBInstallation[] installations = new MongoDBInstallation[0];
-		
-		public DescriptorImpl() {
-			super(MongoBuildWrapper.class);
-			load();
-		}
-		
-		@Override
-		public boolean isApplicable(AbstractProject<?, ?> item) {
-			return true;
-		}
-		
-		@Override
-		public String getDisplayName() {
-			return "MongoDB";
-		}
-		
-		@Override
-		public BuildWrapper newInstance(StaplerRequest req, JSONObject formData)
-				throws hudson.model.Descriptor.FormException {
-			return req.bindJSON(clazz, formData);
-		}
-		
-		public MongoDBInstallation[] getInstallations() {
-			return installations;
-		}
-		
-		public void setInstallations(MongoDBInstallation[] installations) {
-			this.installations = installations;
-			save();
-		}
-		
-		public static FormValidation doCheckStartTimeout(@QueryParameter String value) {
-			if (isEmpty(value)) {
-				return FormValidation.ok();
-			}
-			
-			try {
-				int timeout = Integer.parseInt(value);
-				return timeout >= 0 ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidStartTimeout());
-			} catch (NumberFormatException e) {
-				return FormValidation.error(MongoDB_InvalidStartTimeout());
-			}
-		}
-		
-		public static FormValidation doCheckPort(@QueryParameter String value) {
-			return isPortNumber(value) ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidPortNumber());
-		}
-		
-		public static FormValidation doCheckDbpath(@QueryParameter String value) {
-			if (isEmpty(value)) {
-				return FormValidation.ok();
-			}
-			
-			File file = new File(value);
-			if (!file.isDirectory()) {
-				return FormValidation.error(MongoDB_NotDirectory());
-			}
-			
-			if (file.list().length > 0) {
-				return FormValidation.warning(MongoDB_NotEmptyDirectory());
-			}
-			
-			return FormValidation.ok();
-		}
-		
-		protected static boolean isPortNumber(String value) {
-			if (isEmpty(value)) {
-				return true;
-			}
-			if (StringUtils.isNumeric(value)) {
-				int num = Integer.parseInt(value);
-				return num >= 0 && num <= 65535;
-			}
-			return false;
-		}
-		
-		public ListBoxModel doFillMongodbNameItems() {
-			ListBoxModel m = new ListBoxModel();
-			for (MongoDBInstallation inst : installations) {
-				m.add(inst.getName());
-			}
-			return m;
-		}
-	}
-	
-	private static class IsAbsoluteCheck implements FileCallable<Boolean> {
-		
-		public Boolean invoke(File f, VirtualChannel channel) {
-			return f.isAbsolute();
-		}
-	}
+
+    private String mongodbName;
+    private String dbpath;
+    private String port;
+    private String parameters;
+    private int startTimeout;
+
+    public MongoBuildWrapper() {
+    }
+
+    @DataBoundConstructor
+    public MongoBuildWrapper(String mongodbName, String dbpath, String port, String parameters, int startTimeout) {
+        this.mongodbName = mongodbName;
+        this.dbpath = dbpath;
+        this.port = port;
+        this.startTimeout = startTimeout;
+        this.parameters = parameters;
+    }
+
+    public MongoDBInstallation getMongoDB() {
+        for (MongoDBInstallation i : ((DescriptorImpl) getDescriptor()).getInstallations()) {
+            if (mongodbName != null && i.getName().equals(mongodbName)) {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    public String getMongodbName() {
+        return mongodbName;
+    }
+
+    public String getDbpath() {
+        return dbpath;
+    }
+
+    public String getPort() {
+        return port;
+    }
+
+    public void setMongodbName(String mongodbName) {
+        this.mongodbName = mongodbName;
+    }
+
+    public void setDbpath(String dbpath) {
+        this.dbpath = dbpath;
+    }
+
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    public String getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(String parameters) {
+        this.parameters = parameters;
+    }
+
+    /**
+     * The time (in milliseconds) to wait for mongodb to start
+     * 
+     * @return time in milliseconds
+     */
+    public int getStartTimeout() {
+        return startTimeout;
+    }
+
+    public void setStartTimeout(int startTimeout) {
+        this.startTimeout = startTimeout;
+    }
+
+    @Override
+    public Environment setUp(AbstractBuild build, final Launcher launcher, final BuildListener listener)
+            throws IOException, InterruptedException {
+
+        EnvVars env = build.getEnvironment(listener);
+
+        MongoDBInstallation mongo = getMongoDB().forNode(Computer.currentComputer().getNode(), listener)
+                .forEnvironment(env);
+        ArgumentListBuilder args = new ArgumentListBuilder().add(mongo.getExecutable(launcher));
+        String globalParameters = mongo.getParameters();
+        int globalStartTimeout = mongo.getStartTimeout();
+        final FilePath dbpathFile = setupCmd(launcher, args, build.getWorkspace(), false, globalParameters);
+
+        dbpathFile.deleteRecursive();
+        dbpathFile.mkdirs();
+        return launch(launcher, args, listener, globalStartTimeout);
+    }
+
+    protected Environment launch(final Launcher launcher, ArgumentListBuilder args, final BuildListener listener,
+            int globalStartTimeout) throws IOException, InterruptedException {
+        ProcStarter procStarter = launcher.launch().cmds(args);
+        log(listener, "Executing mongodb start command: " + procStarter.cmds());
+        final Proc proc = procStarter.start();
+
+        try {
+
+            int effectiveTimeout = globalStartTimeout;
+            if (startTimeout > 0) {
+                effectiveTimeout = startTimeout;
+            }
+
+            Boolean startResult = launcher.getChannel().call(new WaitForStartCommand(listener, port, effectiveTimeout));
+            if (!startResult) {
+                log(listener, "ERROR: Failed to start mongodb");
+            }
+        } catch (Exception e) {
+            e.printStackTrace(listener.getLogger());
+            return null;
+        }
+
+        return new BuildWrapper.Environment() {
+            @Override
+            public boolean tearDown(AbstractBuild build, BuildListener listener)
+                    throws IOException, InterruptedException {
+                if (proc.isAlive()) {
+                    log(listener, "Killing mongodb process...");
+                    proc.kill();
+                } else {
+                    log(listener, "Will not kill mongodb process as it is already dead.");
+                }
+                return super.tearDown(build, listener);
+            }
+        };
+    }
+
+    protected FilePath setupCmd(Launcher launcher, ArgumentListBuilder args, FilePath workspace, boolean fork,
+            String globalParameters) throws IOException, InterruptedException {
+
+        if (fork) {
+            args.add("--fork");
+        }
+        args.add("--logpath").add(workspace.child("mongodb.log").getRemote());
+
+        FilePath dbpathFile;
+        if (isEmpty(dbpath)) {
+            dbpathFile = workspace.child("data").child("db");
+        } else {
+            dbpathFile = new FilePath(launcher.getChannel(), dbpath);
+            boolean isAbsolute = dbpathFile.act(new IsAbsoluteCheck());
+            if (!isAbsolute) {
+                dbpathFile = workspace.child(dbpath);
+            }
+        }
+
+        args.add("--dbpath").add(dbpathFile.getRemote());
+
+        if (StringUtils.isNotEmpty(port)) {
+            args.add("--port", port);
+        }
+        String effectiveParameters = globalParameters;
+        if (StringUtils.isNotEmpty(parameters)) {
+            effectiveParameters = parameters;
+        }
+
+        if (StringUtils.isNotEmpty(effectiveParameters)) {
+            for (String parameter : effectiveParameters.split("--")) {
+
+                if (parameter.trim().indexOf(" ") != -1) {
+                    // The parameter is a name value pair e.g. --syncdelay 0
+                    // The construction is done this way so the case where the value is in quotes
+                    // and possibly contains
+                    // space chars is properly handled
+                    String parameterName = parameter.trim().substring(0, parameter.trim().indexOf(" ")).trim();
+                    String parameterValue = parameter.trim().substring(parameter.trim().indexOf(" ")).trim();
+                    if (StringUtils.isNotEmpty(parameterName)) {
+                        args.add("--" + parameterName, parameterValue);
+                    }
+                } else {
+                    // No value parameter e.g. --noprealloc
+                    if (StringUtils.isNotEmpty(parameter.trim())) {
+                        args.add("--" + parameter.trim());
+                    }
+                }
+            }
+        }
+
+        return dbpathFile;
+    }
+
+    private static void log(BuildListener listener, String log) {
+        listener.getLogger().println(String.format("[MongoDB] %s", log));
+    }
+
+    private static class WaitForStartCommand implements Callable<Boolean, Exception> {
+
+        private final BuildListener listener;
+
+        private final String port;
+
+        private int startTimeout;
+
+        public WaitForStartCommand(BuildListener listener, String port, int startTimeout) {
+            this.listener = listener;
+            this.port = StringUtils.defaultIfEmpty(port, "27017");
+            if (startTimeout == 0) {
+                this.startTimeout = 15000;
+            } else {
+                this.startTimeout = startTimeout;
+            }
+        }
+
+        public Boolean call() throws Exception {
+            return waitForStart();
+        }
+
+        protected boolean waitForStart() throws Exception {
+            log(listener, "Starting...");
+            MongoClient mongo = null;
+            String address = "localhost:" + port;
+            try {
+                MongoClientOptions options = MongoClientOptions.builder().serverSelectionTimeout(startTimeout).build();
+                mongo = new MongoClient(address, options);
+                mongo.listDatabaseNames().first();
+                log(listener, "Server ready at " + address);
+                return true;
+            } catch (Exception e) {
+                throw e;
+            } finally {
+                if (mongo != null) {
+                    mongo.close();
+                }
+            }
+        }
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildWrapperDescriptor {
+
+        @CopyOnWrite
+        private volatile MongoDBInstallation[] installations = new MongoDBInstallation[0];
+
+        public DescriptorImpl() {
+            super(MongoBuildWrapper.class);
+            load();
+        }
+
+        @Override
+        public boolean isApplicable(AbstractProject<?, ?> item) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "MongoDB";
+        }
+
+        @Override
+        public BuildWrapper newInstance(StaplerRequest req, JSONObject formData)
+                throws hudson.model.Descriptor.FormException {
+            return req.bindJSON(clazz, formData);
+        }
+
+        public MongoDBInstallation[] getInstallations() {
+            return installations;
+        }
+
+        public void setInstallations(MongoDBInstallation[] installations) {
+            this.installations = installations;
+            save();
+        }
+
+        public static FormValidation doCheckStartTimeout(@QueryParameter String value) {
+            if (isEmpty(value)) {
+                return FormValidation.ok();
+            }
+
+            try {
+                int timeout = Integer.parseInt(value);
+                return timeout >= 0 ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidStartTimeout());
+            } catch (NumberFormatException e) {
+                return FormValidation.error(MongoDB_InvalidStartTimeout());
+            }
+        }
+
+        public static FormValidation doCheckPort(@QueryParameter String value) {
+            return isPortNumber(value) ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidPortNumber());
+        }
+
+        public static FormValidation doCheckDbpath(@QueryParameter String value) {
+            if (isEmpty(value)) {
+                return FormValidation.ok();
+            }
+
+            File file = new File(value);
+            if (!file.isDirectory()) {
+                return FormValidation.error(MongoDB_NotDirectory());
+            }
+
+            if (file.list().length > 0) {
+                return FormValidation.warning(MongoDB_NotEmptyDirectory());
+            }
+
+            return FormValidation.ok();
+        }
+
+        protected static boolean isPortNumber(String value) {
+            if (isEmpty(value)) {
+                return true;
+            }
+            if (StringUtils.isNumeric(value)) {
+                int num = Integer.parseInt(value);
+                return num >= 0 && num <= 65535;
+            }
+            return false;
+        }
+
+        public ListBoxModel doFillMongodbNameItems() {
+            ListBoxModel m = new ListBoxModel();
+            for (MongoDBInstallation inst : installations) {
+                m.add(inst.getName());
+            }
+            return m;
+        }
+    }
+
+    private static class IsAbsoluteCheck implements FileCallable<Boolean> {
+
+        public Boolean invoke(File f, VirtualChannel channel) {
+            return f.isAbsolute();
+        }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
@@ -8,6 +8,7 @@ import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_InvalidStartTimeout
 
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
+import com.thoughtworks.xstream.MarshallingStrategy;
 
 import hudson.CopyOnWrite;
 import hudson.EnvVars;
@@ -28,6 +29,8 @@ import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import jenkins.MasterToSlaveFileCallable;
+import jenkins.security.MasterToSlaveCallable;
 
 import java.io.File;
 import java.io.IOException;
@@ -220,7 +223,7 @@ public class MongoBuildWrapper extends BuildWrapper {
         listener.getLogger().println(String.format("[MongoDB] %s", log));
     }
 
-    private static class WaitForStartCommand implements Callable<Boolean, Exception> {
+    private static class WaitForStartCommand extends MasterToSlaveCallable<Boolean, Exception> {
 
         private BuildListener listener;
 
@@ -348,7 +351,7 @@ public class MongoBuildWrapper extends BuildWrapper {
         }
     }
     
-    private static class IsAbsoluteCheck implements FileCallable<Boolean> {
+    private static class IsAbsoluteCheck extends MasterToSlaveFileCallable<Boolean> {
 
 		public Boolean invoke(File f, VirtualChannel channel){
 			return f.isAbsolute();

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
@@ -145,7 +145,7 @@ public class MongoBuildWrapper extends BuildWrapper {
 			
 			Boolean startResult = launcher.getChannel().call(new WaitForStartCommand(listener, port, effectiveTimeout));
 			if (!startResult) {
-				log(listener, "ERROR: Filed to start mongodb");
+				log(listener, "ERROR: Failed to start mongodb");
 			}
 		} catch (Exception e) {
 			e.printStackTrace(listener.getLogger());
@@ -249,10 +249,12 @@ public class MongoBuildWrapper extends BuildWrapper {
 		protected boolean waitForStart() throws Exception {
 			log(listener, "Starting...");
 			MongoClient mongo = null;
+			String address = "localhost:" + port;
 			try {
 				MongoClientOptions options = MongoClientOptions.builder().serverSelectionTimeout(startTimeout).build();
-				mongo = new MongoClient("localhost:" + port, options);
+				mongo = new MongoClient(address, options);
 				mongo.listDatabaseNames().first();
+				log(listener, "Server ready at " + address);
 				return true;
 			} catch (Exception e) {
 				throw e;

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
@@ -1,11 +1,22 @@
 package org.jenkinsci.plugins.mongodb;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_InvalidPortNumber;
+import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_InvalidStartTimeout;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_NotDirectory;
 import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_NotEmptyDirectory;
-import static org.jenkinsci.plugins.mongodb.Messages.MongoDB_InvalidStartTimeout;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+
 import hudson.CopyOnWrite;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -14,9 +25,9 @@ import hudson.FilePath.FileCallable;
 import hudson.Launcher;
 import hudson.Launcher.ProcStarter;
 import hudson.Proc;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
 import hudson.model.Computer;
 import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
@@ -25,350 +36,327 @@ import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.ConnectException;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-
 import net.sf.json.JSONObject;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-
 public class MongoBuildWrapper extends BuildWrapper {
-
-    private String mongodbName;
-    private String dbpath;
-    private String port;
+	
+	private String mongodbName;
+	private String dbpath;
+	private String port;
 	private String parameters;
 	private int startTimeout;
-
-    public MongoBuildWrapper() {}
-
-    @DataBoundConstructor
-    public MongoBuildWrapper(String mongodbName, String dbpath, String port, String parameters, int startTimeout) {
-        this.mongodbName = mongodbName;
-        this.dbpath = dbpath;
-        this.port = port;
+	
+	public MongoBuildWrapper() {
+	}
+	
+	@DataBoundConstructor
+	public MongoBuildWrapper(String mongodbName, String dbpath, String port, String parameters, int startTimeout) {
+		this.mongodbName = mongodbName;
+		this.dbpath = dbpath;
+		this.port = port;
 		this.startTimeout = startTimeout;
 		this.parameters = parameters;
-    }
-
-    public MongoDBInstallation getMongoDB() {
-        for (MongoDBInstallation i : ((DescriptorImpl) getDescriptor()).getInstallations()) {
-            if (mongodbName != null && i.getName().equals(mongodbName)) {
-                return i;
-            }
-        }
-        return null;
-    }
-
-    public String getMongodbName() {
-        return mongodbName;
-    }
-
-    public String getDbpath() {
-        return dbpath;
-    }
-
-    public String getPort() {
-        return port;
-    }
-
-    public void setMongodbName(String mongodbName) {
-        this.mongodbName = mongodbName;
-    }
-
-    public void setDbpath(String dbpath) {
-        this.dbpath = dbpath;
-    }
-
-    public void setPort(String port) {
-        this.port = port;
-    }
-
-    public String getParameters() {
+	}
+	
+	public MongoDBInstallation getMongoDB() {
+		for (MongoDBInstallation i : ((DescriptorImpl) getDescriptor()).getInstallations()) {
+			if (mongodbName != null && i.getName().equals(mongodbName)) {
+				return i;
+			}
+		}
+		return null;
+	}
+	
+	public String getMongodbName() {
+		return mongodbName;
+	}
+	
+	public String getDbpath() {
+		return dbpath;
+	}
+	
+	public String getPort() {
+		return port;
+	}
+	
+	public void setMongodbName(String mongodbName) {
+		this.mongodbName = mongodbName;
+	}
+	
+	public void setDbpath(String dbpath) {
+		this.dbpath = dbpath;
+	}
+	
+	public void setPort(String port) {
+		this.port = port;
+	}
+	
+	public String getParameters() {
 		return parameters;
 	}
-
+	
 	public void setParameters(String parameters) {
 		this.parameters = parameters;
 	}
-
+	
 	/**
 	 * The time (in milliseconds) to wait for mongodb to start
+	 * 
 	 * @return time in milliseconds
 	 */
 	public int getStartTimeout() {
 		return startTimeout;
 	}
-
+	
 	public void setStartTimeout(int startTimeout) {
 		this.startTimeout = startTimeout;
 	}
-
+	
 	@Override
-    public Environment setUp(AbstractBuild build, final Launcher launcher, final BuildListener listener) throws IOException, InterruptedException {
-
-        EnvVars env = build.getEnvironment(listener);
-
-        MongoDBInstallation mongo = getMongoDB()
-            .forNode(Computer.currentComputer().getNode(), listener)
-            .forEnvironment(env);
-        ArgumentListBuilder args = new ArgumentListBuilder().add(mongo.getExecutable(launcher));
-        String globalParameters = mongo.getParameters();
-        int globalStartTimeout = mongo.getStartTimeout();
-        final FilePath dbpathFile = setupCmd(launcher,args, build.getWorkspace(), false, globalParameters);
-
-    	dbpathFile.deleteRecursive();
-    	dbpathFile.mkdirs();
-        return launch(launcher, args, listener, globalStartTimeout);
-    }
-
-    protected Environment launch(final Launcher launcher, ArgumentListBuilder args, final BuildListener listener, int globalStartTimeout) throws IOException, InterruptedException {
-        ProcStarter procStarter = launcher.launch().cmds(args);
-        log(listener, "Executing mongodb start command: "+procStarter.cmds());
+	public Environment setUp(AbstractBuild build, final Launcher launcher, final BuildListener listener)
+			throws IOException, InterruptedException {
+		
+		EnvVars env = build.getEnvironment(listener);
+		
+		MongoDBInstallation mongo = getMongoDB().forNode(Computer.currentComputer().getNode(), listener).forEnvironment(
+				env);
+		ArgumentListBuilder args = new ArgumentListBuilder().add(mongo.getExecutable(launcher));
+		String globalParameters = mongo.getParameters();
+		int globalStartTimeout = mongo.getStartTimeout();
+		final FilePath dbpathFile = setupCmd(launcher, args, build.getWorkspace(), false, globalParameters);
+		
+		dbpathFile.deleteRecursive();
+		dbpathFile.mkdirs();
+		return launch(launcher, args, listener, globalStartTimeout);
+	}
+	
+	protected Environment launch(final Launcher launcher, ArgumentListBuilder args, final BuildListener listener,
+			int globalStartTimeout) throws IOException, InterruptedException {
+		ProcStarter procStarter = launcher.launch().cmds(args);
+		log(listener, "Executing mongodb start command: " + procStarter.cmds());
 		final Proc proc = procStarter.start();
-
-        try {
-        	
-        	int effectiveTimeout = globalStartTimeout;
-        	if(startTimeout>0) {
-        		effectiveTimeout = startTimeout;
-        	}
-        	
-            Boolean startResult = launcher.getChannel().call(new WaitForStartCommand(listener, port, effectiveTimeout));
-            if(!startResult) {
-                log(listener, "ERROR: Filed to start mongodb");
-            }
-        } catch (Exception e) {
-            e.printStackTrace(listener.getLogger());
-            return null;
-        }
-
-        return new BuildWrapper.Environment() {
-            @Override
-            public boolean tearDown(AbstractBuild build, BuildListener listener)
-                    throws IOException, InterruptedException {
-                if (proc.isAlive()) {
-                    log(listener, "Killing mongodb process...");
-                    proc.kill();
-                } else {
-                    log(listener, "Will not kill mongodb process as it is already dead.");
-                }
-                return super.tearDown(build, listener);
-            }
-        };
-    }
-
-    protected FilePath setupCmd(Launcher launcher, ArgumentListBuilder args, FilePath workspace, boolean fork, String globalParameters) throws IOException, InterruptedException {
-
-        if (fork) {
-        	args.add("--fork");
-        }
-        args.add("--logpath").add(workspace.child("mongodb.log").getRemote());
-
-        FilePath dbpathFile;
-        if (isEmpty(dbpath)) {
-            dbpathFile = workspace.child("data").child("db");
-        } else {
-            dbpathFile = new FilePath(launcher.getChannel(),dbpath);
-            boolean isAbsolute = dbpathFile.act(new IsAbsoluteCheck());
-            if (!isAbsolute) {
-                dbpathFile = workspace.child(dbpath);
-            }
-        }
-        
-        args.add("--dbpath").add(dbpathFile.getRemote());
-
-        if (StringUtils.isNotEmpty(port)) {
-            args.add("--port", port);
-        }
-        String effectiveParameters = globalParameters;
-        if (StringUtils.isNotEmpty(parameters)) {
-        	effectiveParameters = parameters;
-        }
-        
-        if (StringUtils.isNotEmpty(effectiveParameters)) {
-        	for (String parameter : effectiveParameters.split("--")) {
-        		
-        		if(parameter.trim().indexOf(" ")!=-1) {
-        			//The parameter is a name value pair e.g. --syncdelay 0
-        			// The construction is done this way so the case where the value is in quotes and possibly contains space chars is properly handled 
-        			String parameterName = parameter.trim().substring(0, parameter.trim().indexOf(" ")).trim();
-        			String parameterValue = parameter.trim().substring(parameter.trim().indexOf(" ")).trim();
-        			if(StringUtils.isNotEmpty(parameterName)) {
-        				args.add("--"+parameterName, parameterValue);
-        			}
-        		} else {
-        			//No value parameter e.g. --noprealloc
-        			if(StringUtils.isNotEmpty(parameter.trim())) {
-        				args.add("--"+parameter.trim());
-        			}
-        		}
+		
+		try {
+			
+			int effectiveTimeout = globalStartTimeout;
+			if (startTimeout > 0) {
+				effectiveTimeout = startTimeout;
 			}
-        }
-
-        return dbpathFile;
-    }
-
-    private static void log(BuildListener listener, String log) {
-        listener.getLogger().println(String.format("[MongoDB] %s", log));
-    }
-
-    private static class WaitForStartCommand implements Callable<Boolean, Exception> {
-
-        private BuildListener listener;
-
-        private String port;
-
+			
+			Boolean startResult = launcher.getChannel().call(new WaitForStartCommand(listener, port, effectiveTimeout));
+			if (!startResult) {
+				log(listener, "ERROR: Filed to start mongodb");
+			}
+		} catch (Exception e) {
+			e.printStackTrace(listener.getLogger());
+			return null;
+		}
+		
+		return new BuildWrapper.Environment() {
+			@Override
+			public boolean tearDown(AbstractBuild build, BuildListener listener)
+					throws IOException, InterruptedException {
+				if (proc.isAlive()) {
+					log(listener, "Killing mongodb process...");
+					proc.kill();
+				} else {
+					log(listener, "Will not kill mongodb process as it is already dead.");
+				}
+				return super.tearDown(build, listener);
+			}
+		};
+	}
+	
+	protected FilePath setupCmd(Launcher launcher, ArgumentListBuilder args, FilePath workspace, boolean fork,
+			String globalParameters) throws IOException, InterruptedException {
+		
+		if (fork) {
+			args.add("--fork");
+		}
+		args.add("--logpath").add(workspace.child("mongodb.log").getRemote());
+		
+		FilePath dbpathFile;
+		if (isEmpty(dbpath)) {
+			dbpathFile = workspace.child("data").child("db");
+		} else {
+			dbpathFile = new FilePath(launcher.getChannel(), dbpath);
+			boolean isAbsolute = dbpathFile.act(new IsAbsoluteCheck());
+			if (!isAbsolute) {
+				dbpathFile = workspace.child(dbpath);
+			}
+		}
+		
+		args.add("--dbpath").add(dbpathFile.getRemote());
+		
+		if (StringUtils.isNotEmpty(port)) {
+			args.add("--port", port);
+		}
+		String effectiveParameters = globalParameters;
+		if (StringUtils.isNotEmpty(parameters)) {
+			effectiveParameters = parameters;
+		}
+		
+		if (StringUtils.isNotEmpty(effectiveParameters)) {
+			for (String parameter : effectiveParameters.split("--")) {
+				
+				if (parameter.trim().indexOf(" ") != -1) {
+					// The parameter is a name value pair e.g. --syncdelay 0
+					// The construction is done this way so the case where the value is in quotes and possibly contains
+					// space chars is properly handled
+					String parameterName = parameter.trim().substring(0, parameter.trim().indexOf(" ")).trim();
+					String parameterValue = parameter.trim().substring(parameter.trim().indexOf(" ")).trim();
+					if (StringUtils.isNotEmpty(parameterName)) {
+						args.add("--" + parameterName, parameterValue);
+					}
+				} else {
+					// No value parameter e.g. --noprealloc
+					if (StringUtils.isNotEmpty(parameter.trim())) {
+						args.add("--" + parameter.trim());
+					}
+				}
+			}
+		}
+		
+		return dbpathFile;
+	}
+	
+	private static void log(BuildListener listener, String log) {
+		listener.getLogger().println(String.format("[MongoDB] %s", log));
+	}
+	
+	private static class WaitForStartCommand implements Callable<Boolean, Exception> {
+		
+		private final BuildListener listener;
+		
+		private final String port;
+		
 		private int startTimeout;
-
-		private long waitStart;
-
-        public WaitForStartCommand(BuildListener listener, String port, int startTimeout) {
-            this.listener = listener;
-            this.port = StringUtils.defaultIfEmpty(port, "27017");
-            if(startTimeout == 0) {
-            	this.startTimeout = 15000;
-            } else {
-            	this.startTimeout = startTimeout;
-            }
-        }
-
-        public Boolean call() throws Exception {
-        	waitStart = System.currentTimeMillis();
-            return waitForStart();
-        }
-
-        protected boolean waitForStart() throws Exception {
-            log(listener, "Starting...");
-            HttpURLConnection conn = null;
-            try {
-                conn = (HttpURLConnection) new URL("http://localhost:" + port).openConnection();
-                if (conn.getResponseCode() == 200) {
-                    log(listener, "MongoDB running at:"+new URL("http://localhost:" + port).toString());
-                    return true;
-                } else {
-                    return false;
-                }
-            } catch (MalformedURLException e) {
-                throw e;
-            } catch (ConnectException e) {
-                try {
-                    if (startTimeout>=System.currentTimeMillis()-waitStart) {
-                        Thread.sleep(1000);
-                        return waitForStart();
-                    } else {
-                        return false;
-                    }
-                } catch (InterruptedException e1) {
-                    throw e;
-                }
-            } catch (IOException e) {
-                throw e;
-            } finally {
-                if (conn != null)
-                    conn.disconnect();
-            }
-        }
-    }
-
-    @Extension
-    public static final class DescriptorImpl extends BuildWrapperDescriptor {
-
-        @CopyOnWrite
-        private volatile MongoDBInstallation[] installations = new MongoDBInstallation[0];
-
-        public DescriptorImpl() {
-            super(MongoBuildWrapper.class);
-            load();
-        }
-
-        @Override
-        public boolean isApplicable(AbstractProject<?, ?> item) {
-            return true;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "MongoDB";
-        }
-
-        @Override
-        public BuildWrapper newInstance(StaplerRequest req, JSONObject formData) throws hudson.model.Descriptor.FormException {
-            return req.bindJSON(clazz, formData);
-        }
-
-        public MongoDBInstallation[] getInstallations() {
-            return installations;
-        }
-
-        public void setInstallations(MongoDBInstallation[] installations) {
-            this.installations = installations;
-            save();
-        }
-
-        public static FormValidation doCheckStartTimeout(@QueryParameter String value) {
-        	if(isEmpty(value)) {
-        		return FormValidation.ok();
-        	}
-        	
-        	try {
-        		int timeout = Integer.parseInt(value);
-        		return timeout>=0 ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidStartTimeout());
-        	} catch (NumberFormatException e) {
-        		return FormValidation.error(MongoDB_InvalidStartTimeout());
-        	}
-        }
-        
-        public static FormValidation doCheckPort(@QueryParameter String value) {
-            return isPortNumber(value) ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidPortNumber());
-        }
-
-        public static FormValidation doCheckDbpath(@QueryParameter String value) {
-            if (isEmpty(value))
-                return FormValidation.ok();
-
-            File file = new File(value);
-            if (!file.isDirectory())
-                return FormValidation.error(MongoDB_NotDirectory());
-
-            if (file.list().length > 0)
-                return FormValidation.warning(MongoDB_NotEmptyDirectory());
-
-            return FormValidation.ok();
-        }
-
-        protected static boolean isPortNumber(String value) {
-            if (isEmpty(value)) {
-                return true;
-            }
-            if (StringUtils.isNumeric(value)) {
-                int num = Integer.parseInt(value);
-                return num >= 0 && num <= 65535;
-            }
-            return false;
-        }
-
-        public ListBoxModel doFillMongodbNameItems() {
-            ListBoxModel m = new ListBoxModel();
-            for (MongoDBInstallation inst : installations) {
-                m.add(inst.getName());
-            }
-            return m;
-        }
-    }
-    
-    private static class IsAbsoluteCheck implements FileCallable<Boolean> {
-
-		public Boolean invoke(File f, VirtualChannel channel){
+		
+		public WaitForStartCommand(BuildListener listener, String port, int startTimeout) {
+			this.listener = listener;
+			this.port = StringUtils.defaultIfEmpty(port, "27017");
+			if (startTimeout == 0) {
+				this.startTimeout = 15000;
+			} else {
+				this.startTimeout = startTimeout;
+			}
+		}
+		
+		public Boolean call() throws Exception {
+			return waitForStart();
+		}
+		
+		protected boolean waitForStart() throws Exception {
+			log(listener, "Starting...");
+			MongoClient mongo = null;
+			try {
+				MongoClientOptions options = MongoClientOptions.builder().serverSelectionTimeout(startTimeout).build();
+				mongo = new MongoClient("localhost:" + port, options);
+				mongo.listDatabaseNames().first();
+				return true;
+			} catch (Exception e) {
+				throw e;
+			} finally {
+				if (mongo != null) {
+					mongo.close();
+				}
+			}
+		}
+	}
+	
+	@Extension
+	public static final class DescriptorImpl extends BuildWrapperDescriptor {
+		
+		@CopyOnWrite
+		private volatile MongoDBInstallation[] installations = new MongoDBInstallation[0];
+		
+		public DescriptorImpl() {
+			super(MongoBuildWrapper.class);
+			load();
+		}
+		
+		@Override
+		public boolean isApplicable(AbstractProject<?, ?> item) {
+			return true;
+		}
+		
+		@Override
+		public String getDisplayName() {
+			return "MongoDB";
+		}
+		
+		@Override
+		public BuildWrapper newInstance(StaplerRequest req, JSONObject formData)
+				throws hudson.model.Descriptor.FormException {
+			return req.bindJSON(clazz, formData);
+		}
+		
+		public MongoDBInstallation[] getInstallations() {
+			return installations;
+		}
+		
+		public void setInstallations(MongoDBInstallation[] installations) {
+			this.installations = installations;
+			save();
+		}
+		
+		public static FormValidation doCheckStartTimeout(@QueryParameter String value) {
+			if (isEmpty(value)) {
+				return FormValidation.ok();
+			}
+			
+			try {
+				int timeout = Integer.parseInt(value);
+				return timeout >= 0 ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidStartTimeout());
+			} catch (NumberFormatException e) {
+				return FormValidation.error(MongoDB_InvalidStartTimeout());
+			}
+		}
+		
+		public static FormValidation doCheckPort(@QueryParameter String value) {
+			return isPortNumber(value) ? FormValidation.ok() : FormValidation.error(MongoDB_InvalidPortNumber());
+		}
+		
+		public static FormValidation doCheckDbpath(@QueryParameter String value) {
+			if (isEmpty(value)) {
+				return FormValidation.ok();
+			}
+			
+			File file = new File(value);
+			if (!file.isDirectory()) {
+				return FormValidation.error(MongoDB_NotDirectory());
+			}
+			
+			if (file.list().length > 0) {
+				return FormValidation.warning(MongoDB_NotEmptyDirectory());
+			}
+			
+			return FormValidation.ok();
+		}
+		
+		protected static boolean isPortNumber(String value) {
+			if (isEmpty(value)) {
+				return true;
+			}
+			if (StringUtils.isNumeric(value)) {
+				int num = Integer.parseInt(value);
+				return num >= 0 && num <= 65535;
+			}
+			return false;
+		}
+		
+		public ListBoxModel doFillMongodbNameItems() {
+			ListBoxModel m = new ListBoxModel();
+			for (MongoDBInstallation inst : installations) {
+				m.add(inst.getName());
+			}
+			return m;
+		}
+	}
+	
+	private static class IsAbsoluteCheck implements FileCallable<Boolean> {
+		
+		public Boolean invoke(File f, VirtualChannel channel) {
 			return f.isAbsolute();
 		}
 	}

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
@@ -46,15 +46,15 @@ public class MongoBuildWrapper extends BuildWrapper {
 	private String parameters;
 	private int startTimeout;
 
-	public MongoBuildWrapper() {}
+    public MongoBuildWrapper() {}
 
     @DataBoundConstructor
     public MongoBuildWrapper(String mongodbName, String dbpath, String port, String parameters, int startTimeout) {
         this.mongodbName = mongodbName;
         this.dbpath = dbpath;
         this.port = port;
-        this.startTimeout = startTimeout;
-        this.parameters = parameters;
+		this.startTimeout = startTimeout;
+		this.parameters = parameters;
     }
 
     public MongoDBInstallation getMongoDB() {
@@ -91,7 +91,7 @@ public class MongoBuildWrapper extends BuildWrapper {
     }
 
     public String getParameters() {
-    	return parameters;
+		return parameters;
 	}
 
 	public void setParameters(String parameters) {
@@ -100,7 +100,6 @@ public class MongoBuildWrapper extends BuildWrapper {
 
 	/**
 	 * The time (in milliseconds) to wait for mongodb to start
-	 * 
 	 * @return time in milliseconds
 	 */
 	public int getStartTimeout() {
@@ -116,33 +115,33 @@ public class MongoBuildWrapper extends BuildWrapper {
 
         EnvVars env = build.getEnvironment(listener);
 
-        MongoDBInstallation mongo = getMongoDB().forNode(Computer.currentComputer().getNode(), listener)
+        MongoDBInstallation mongo = getMongoDB()
+                .forNode(Computer.currentComputer().getNode(), listener)
                 .forEnvironment(env);
         ArgumentListBuilder args = new ArgumentListBuilder().add(mongo.getExecutable(launcher));
         String globalParameters = mongo.getParameters();
         int globalStartTimeout = mongo.getStartTimeout();
-        final FilePath dbpathFile = setupCmd(launcher, args, build.getWorkspace(), false, globalParameters);
+        final FilePath dbpathFile = setupCmd(launcher,args, build.getWorkspace(), false, globalParameters);
 
-        dbpathFile.deleteRecursive();
-        dbpathFile.mkdirs();
+    	dbpathFile.deleteRecursive();
+    	dbpathFile.mkdirs();
         return launch(launcher, args, listener, globalStartTimeout);
     }
 
-    protected Environment launch(final Launcher launcher, ArgumentListBuilder args, final BuildListener listener,
-            int globalStartTimeout) throws IOException, InterruptedException {
+    protected Environment launch(final Launcher launcher, ArgumentListBuilder args, final BuildListener listener, int globalStartTimeout) throws IOException, InterruptedException {
         ProcStarter procStarter = launcher.launch().cmds(args);
-        log(listener, "Executing mongodb start command: " + procStarter.cmds());
-        final Proc proc = procStarter.start();
+        log(listener, "Executing mongodb start command: "+procStarter.cmds());
+		final Proc proc = procStarter.start();
 
         try {
-
-            int effectiveTimeout = globalStartTimeout;
+        	
+        	int effectiveTimeout = globalStartTimeout;
             if (startTimeout > 0) {
-                effectiveTimeout = startTimeout;
-            }
-
+        		effectiveTimeout = startTimeout;
+        	}
+        	
             Boolean startResult = launcher.getChannel().call(new WaitForStartCommand(listener, port, effectiveTimeout));
-            if (!startResult) {
+            if(!startResult) {
                 log(listener, "ERROR: Failed to start mongodb");
             }
         } catch (Exception e) {
@@ -165,11 +164,10 @@ public class MongoBuildWrapper extends BuildWrapper {
         };
     }
 
-    protected FilePath setupCmd(Launcher launcher, ArgumentListBuilder args, FilePath workspace, boolean fork,
-            String globalParameters) throws IOException, InterruptedException {
+    protected FilePath setupCmd(Launcher launcher, ArgumentListBuilder args, FilePath workspace, boolean fork, String globalParameters) throws IOException, InterruptedException {
 
         if (fork) {
-            args.add("--fork");
+        	args.add("--fork");
         }
         args.add("--logpath").add(workspace.child("mongodb.log").getRemote());
 
@@ -177,13 +175,13 @@ public class MongoBuildWrapper extends BuildWrapper {
         if (isEmpty(dbpath)) {
             dbpathFile = workspace.child("data").child("db");
         } else {
-            dbpathFile = new FilePath(launcher.getChannel(), dbpath);
+            dbpathFile = new FilePath(launcher.getChannel(),dbpath);
             boolean isAbsolute = dbpathFile.act(new IsAbsoluteCheck());
             if (!isAbsolute) {
                 dbpathFile = workspace.child(dbpath);
             }
         }
-
+        
         args.add("--dbpath").add(dbpathFile.getRemote());
 
         if (StringUtils.isNotEmpty(port)) {
@@ -191,12 +189,12 @@ public class MongoBuildWrapper extends BuildWrapper {
         }
         String effectiveParameters = globalParameters;
         if (StringUtils.isNotEmpty(parameters)) {
-            effectiveParameters = parameters;
+        	effectiveParameters = parameters;
         }
-
+        
         if (StringUtils.isNotEmpty(effectiveParameters)) {
-            for (String parameter : effectiveParameters.split("--")) {
-
+        	for (String parameter : effectiveParameters.split("--")) {
+            	
                 if (parameter.trim().indexOf(" ") != -1) {
                     // The parameter is a name value pair e.g. --syncdelay 0
                     // The construction is done this way so the case where the value is in quotes

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapper.java
@@ -43,11 +43,10 @@ public class MongoBuildWrapper extends BuildWrapper {
     private String mongodbName;
     private String dbpath;
     private String port;
-    private String parameters;
-    private int startTimeout;
+	private String parameters;
+	private int startTimeout;
 
-    public MongoBuildWrapper() {
-    }
+	public MongoBuildWrapper() {}
 
     @DataBoundConstructor
     public MongoBuildWrapper(String mongodbName, String dbpath, String port, String parameters, int startTimeout) {
@@ -92,29 +91,28 @@ public class MongoBuildWrapper extends BuildWrapper {
     }
 
     public String getParameters() {
-        return parameters;
-    }
+    	return parameters;
+	}
 
-    public void setParameters(String parameters) {
-        this.parameters = parameters;
-    }
+	public void setParameters(String parameters) {
+		this.parameters = parameters;
+	}
 
-    /**
-     * The time (in milliseconds) to wait for mongodb to start
-     * 
-     * @return time in milliseconds
-     */
-    public int getStartTimeout() {
-        return startTimeout;
-    }
+	/**
+	 * The time (in milliseconds) to wait for mongodb to start
+	 * 
+	 * @return time in milliseconds
+	 */
+	public int getStartTimeout() {
+		return startTimeout;
+	}
 
-    public void setStartTimeout(int startTimeout) {
-        this.startTimeout = startTimeout;
-    }
+	public void setStartTimeout(int startTimeout) {
+		this.startTimeout = startTimeout;
+	}
 
-    @Override
-    public Environment setUp(AbstractBuild build, final Launcher launcher, final BuildListener listener)
-            throws IOException, InterruptedException {
+	@Override
+    public Environment setUp(AbstractBuild build, final Launcher launcher, final BuildListener listener) throws IOException, InterruptedException {
 
         EnvVars env = build.getEnvironment(listener);
 

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoDBInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoDBInstallation.java
@@ -10,17 +10,14 @@ import hudson.Functions;
 import hudson.Launcher;
 import hudson.model.EnvironmentSpecific;
 import hudson.model.TaskListener;
-import hudson.model.Hudson;
 import hudson.model.Node;
-import hudson.remoting.Callable;
 import hudson.slaves.NodeSpecific;
 import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstaller;
 import hudson.tools.ToolProperty;
-import hudson.tools.ToolPropertyDescriptor;
 import hudson.tools.ToolInstallation;
-import hudson.util.DescribableList;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 
 import java.io.File;
@@ -30,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -75,7 +71,11 @@ public class MongoDBInstallation extends ToolInstallation implements Environment
     public String getExecutable(final Launcher launcher) throws IOException, InterruptedException {
         return launcher.getChannel().call(new MasterToSlaveCallable<String, IOException>() {
             public String call() throws IOException {
-                File homeDir = new File(getHome());
+            	String home = getHome();
+            	if (home == null) {
+                    throw new FileNotFoundException("No home directory defined");
+                }
+                File homeDir = new File(home);
                 if (!(homeDir.exists() && homeDir.isDirectory())) {
                     throw new FileNotFoundException(String.format("No such directory. [%s]", homeDir));
                 }
@@ -90,7 +90,11 @@ public class MongoDBInstallation extends ToolInstallation implements Environment
     }
 
     protected File findExecutable(File parent) {
-        for (File child : parent.listFiles()) {
+    	File[] children = parent.listFiles();
+    	if(children == null) {
+    		return null;
+    	}
+        for (File child : children) {
             if (child.isFile() && (parent.getName() + "/" + child.getName()).equals(getExeFile())) {
                 return child;
             } else if (child.isDirectory()) {
@@ -122,12 +126,20 @@ public class MongoDBInstallation extends ToolInstallation implements Environment
 
         @Override
         public MongoDBInstallation[] getInstallations() {
-            return Hudson.getInstance().getDescriptorByType(MongoBuildWrapper.DescriptorImpl.class).getInstallations();
+        	Jenkins jenkins = Jenkins.getInstance();
+        	if(jenkins == null) {
+        		throw new RuntimeException("No Jenkins instance available");
+        	}
+            return jenkins.getDescriptorByType(MongoBuildWrapper.DescriptorImpl.class).getInstallations();
         }
 
         @Override
         public void setInstallations(MongoDBInstallation... installations) {
-            Hudson.getInstance().getDescriptorByType(MongoBuildWrapper.DescriptorImpl.class).setInstallations(installations);
+        	Jenkins jenkins = Jenkins.getInstance();
+        	if(jenkins == null) {
+        		throw new RuntimeException("No Jenkins instance available");
+        	}
+            jenkins.getDescriptorByType(MongoBuildWrapper.DescriptorImpl.class).setInstallations(installations);
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/mongodb/MongoDBInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/mongodb/MongoDBInstallation.java
@@ -21,6 +21,7 @@ import hudson.tools.ToolPropertyDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
+import jenkins.security.MasterToSlaveCallable;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -72,7 +73,7 @@ public class MongoDBInstallation extends ToolInstallation implements Environment
 
 
     public String getExecutable(final Launcher launcher) throws IOException, InterruptedException {
-        return launcher.getChannel().call(new Callable<String, IOException>() {
+        return launcher.getChannel().call(new MasterToSlaveCallable<String, IOException>() {
             public String call() throws IOException {
                 File homeDir = new File(getHome());
                 if (!(homeDir.exists() && homeDir.isDirectory())) {
@@ -129,8 +130,8 @@ public class MongoDBInstallation extends ToolInstallation implements Environment
             Hudson.getInstance().getDescriptorByType(MongoBuildWrapper.DescriptorImpl.class).setInstallations(installations);
         }
 
-
-        public static FormValidation doCheckName(@QueryParameter String value) {
+        @Override
+        public FormValidation doCheckName(@QueryParameter String value) {
             return FormValidation.validateRequired(value);
         }
 		
@@ -147,7 +148,8 @@ public class MongoDBInstallation extends ToolInstallation implements Environment
         	}
 	    }
 
-        public static FormValidation doCheckHome(@QueryParameter File value) {
+        @Override
+        public FormValidation doCheckHome(@QueryParameter File value) {
             if (StringUtils.isEmpty(value.getPath()))
                 return FormValidation.ok();
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/main/resources/org/jenkinsci/plugins/mongodb/MongoBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mongodb/MongoBuildWrapper/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="MongoDB" field="mongodbName">
     <f:select />

--- a/src/main/resources/org/jenkinsci/plugins/mongodb/MongoDBInstallation/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mongodb/MongoDBInstallation/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%name}" field="name">
     <f:textbox />

--- a/src/test/java/org/jenkinsci/plugins/mongodb/CompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mongodb/CompatibilityTest.java
@@ -1,32 +1,34 @@
 package org.jenkinsci.plugins.mongodb;
 
 import hudson.model.FreeStyleProject;
-import org.jvnet.hudson.test.HudsonTestCase;
+
+import org.junit.Assert;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
  * @author Kiyotaka Oku
  */
-public class CompatibilityTest extends HudsonTestCase {
+public class CompatibilityTest extends JenkinsRule {
 
     @LocalData
     public void test_1_2_to_1_3() {
 
-        MongoDBInstallation[] installations = hudson.getDescriptorByType(MongoDBInstallation.DescriptorImpl.class).getInstallations();
-        assertEquals(1, installations.length);
+        MongoDBInstallation[] installations = jenkins.getDescriptorByType(MongoDBInstallation.DescriptorImpl.class).getInstallations();
+        Assert.assertEquals(1, installations.length);
 
         MongoDBInstallation inst = installations[0];
-        assertEquals(null, inst.getParameters());
-        assertEquals(0, inst.getStartTimeout());
+        Assert.assertEquals(null, inst.getParameters());
+        Assert.assertEquals(0, inst.getStartTimeout());
 
-        FreeStyleProject job = (FreeStyleProject) hudson.getItem("test");
-        MongoBuildWrapper wrapper = (MongoBuildWrapper) job.getBuildWrappers().get(hudson.getDescriptor(MongoBuildWrapper.class));
+        FreeStyleProject job = (FreeStyleProject) jenkins.getItem("test");
+        MongoBuildWrapper wrapper = (MongoBuildWrapper) job.getBuildWrappers().get(jenkins.getDescriptor(MongoBuildWrapper.class));
 
-        assertNotNull(wrapper);
-        assertEquals("mongo", wrapper.getMongodbName());
-        assertEquals("data", wrapper.getDbpath());
-        assertEquals("10000", wrapper.getPort());
-        assertNull(wrapper.getParameters());
-        assertEquals(0, wrapper.getStartTimeout());
+        Assert.assertNotNull(wrapper);
+        Assert.assertEquals("mongo", wrapper.getMongodbName());
+        Assert.assertEquals("data", wrapper.getDbpath());
+        Assert.assertEquals("10000", wrapper.getPort());
+        Assert.assertNull(wrapper.getParameters());
+        Assert.assertEquals(0, wrapper.getStartTimeout());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapperTest.java
@@ -4,6 +4,9 @@ import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.remoting.Callable;
@@ -31,7 +34,7 @@ public class MongoBuildWrapperTest {
 	private VirtualChannel mockChannel;
 
     @Before
-    public void init() {
+    public void init() throws IOException {
         workspace = new FilePath(tempFolder.newFolder("workspace"));
         mockLauncher = mock(Launcher.class);
         mockChannel = mock(VirtualChannel.class);

--- a/src/test/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapperValidationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mongodb/MongoBuildWrapperValidationTest.java
@@ -102,7 +102,7 @@ public class MongoBuildWrapperValidationTest {
         public TemporaryFolder tmpFolder = new TemporaryFolder();
 
         @Test
-        public void empty_directory() {
+        public void empty_directory() throws IOException {
             File file = tmpFolder.newFolder("foo");
             FormValidation actual = MongoBuildWrapper.DescriptorImpl.doCheckDbpath(file.getAbsolutePath());
             assertEquals(Kind.OK, actual.kind);

--- a/src/test/java/org/jenkinsci/plugins/mongodb/MongoDBInstallationValidationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mongodb/MongoDBInstallationValidationTest.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.mongodb;
 
-import static org.jenkinsci.plugins.mongodb.MongoDBInstallation.DescriptorImpl.doCheckHome;
 import static org.junit.Assert.assertEquals;
 import static org.jenkinsci.plugins.mongodb.Messages.*;
 import hudson.util.FormValidation;
@@ -24,23 +23,25 @@ public class MongoDBInstallationValidationTest {
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
+    
+    private MongoDBInstallation.DescriptorImpl descr = new MongoDBInstallation.DescriptorImpl();
 
     @Test
     public void doCheckHome_Empty() {
-        assertEquals(Kind.OK, doCheckHome(new File("")).kind);
+        assertEquals(Kind.OK, descr.doCheckHome(new File("")).kind);
     }
 
     @Test
     public void doCheckHome_File() throws IOException {
-        FormValidation actual = doCheckHome(tempFolder.newFile("file"));
+        FormValidation actual = descr.doCheckHome(tempFolder.newFile("file"));
         assertEquals(Kind.ERROR, actual.kind);
         assertEquals(MongoDB_NotDirectory(), actual.getMessage());
     }
 
     @Test
-    public void doCheckHome_Not_MongoDB_Home() {
+    public void doCheckHome_Not_MongoDB_Home() throws IOException {
         File value = tempFolder.newFolder("folder");
-        FormValidation actual = doCheckHome(value);
+        FormValidation actual = descr.doCheckHome(value);
         assertEquals(Kind.ERROR, actual.kind);
         assertEquals(MongoDB_NotMongoDBDirectory(value), actual.getMessage());
     }
@@ -51,7 +52,7 @@ public class MongoDBInstallationValidationTest {
         new File(value, "bin").mkdir();
         new File(value, "bin/mongod").createNewFile();
 
-        FormValidation actual = doCheckHome(value);
+        FormValidation actual = descr.doCheckHome(value);
         assertEquals(Kind.OK, actual.kind);
     }
     


### PR DESCRIPTION
Add support for MongoDB versions 3.6 and later.

MongoDB has deprecated HTTP access on default port (27017) and from version 3.6 onwards, it won't be available at all. HTTP protocol removal breaks this MongoDB plugin because the plugin uses HttpURLConnection to check if the server is started and alive.

This pull request fixes WaitForStartCommand and therefore provides support for MongoDB versions 3.6 and later. Instead of using HttpURLConnection, it uses the standard MongoDB java driver to check if the server is available.

This pull request also includes several commits to preserve the original code formatting to make the actual substance more readable (originally, I re-formatted almost all source code in the relevant file but later realized that it makes the diff more difficult to read).